### PR TITLE
removed unexpected variables from namaster call

### DIFF
--- a/test/test_pspy_namaster_spin0.py
+++ b/test/test_pspy_namaster_spin0.py
@@ -83,7 +83,7 @@ lb,Cb_pspy= so_spectra.bin_spectra(l,ps,binning_file,lmax,type=type,mbb_inv=mbb_
 # Compute spin 0 spectra a la namaster
 nlb=50
 field=nmt.NmtField(window.data,[split.data])
-cl_coupled=nmt.compute_coupled_cell(field,field,n_iter=niter)
+cl_coupled=nmt.compute_coupled_cell(field,field)
 b=nmt.NmtBin(nside,nlb=nlb)
 lb=b.get_effective_ells()
 w0=nmt.NmtWorkspace()

--- a/test/test_pspy_namaster_spin0and2.py
+++ b/test/test_pspy_namaster_spin0and2.py
@@ -106,7 +106,7 @@ w2=nmt.NmtWorkspace()
 w2.compute_coupling_matrix(field_2,field_2,b)
 
 def compute_master(f_a,f_b,wsp) :
-    cl_coupled=nmt.compute_coupled_cell(f_a,f_b,n_iter=0)
+    cl_coupled=nmt.compute_coupled_cell(f_a,f_b)
     cl_decoupled=wsp.decouple_cell(cl_coupled)
     return cl_decoupled
 


### PR DESCRIPTION
I can't find n_iter as input to nmt.compute_coupled_cell() call (using the latest NaMaster version as 120818). Removed the variable and things worked as expected. 