### PR TITLE
repair foreground model calls in best-fit script

### DIFF
--- a/project/data_analysis/paramfiles/global_dr6_v3_4pass.dict
+++ b/project/data_analysis/paramfiles/global_dr6_v3_4pass.dict
@@ -110,7 +110,7 @@ window_pol_dr6_pa6_f150 =  "windows/window_dr6_pa6_f150.fits"
 cosmo_params = {"cosmomc_theta":0.0104085, "logA": 3.044, "ombh2": 0.02237, "omch2": 0.1200, "ns": 0.9649, "Alens": 1.0, "tau": 0.0544}
 fg_norm = {"nu_0": 150.0, "ell_0": 3000, "T_CMB": 2.725}
 fg_components =  ["cibc", "cibp", "kSZ", "radio", "tSZ"]
-fg_params = {"a_tSZ": 3.30, "a_kSZ": 1.60, "a_p": 6.90, "beta_p": 2.08, "a_c": 4.90, "beta_c": 2.20, "n_CIBC": 1.20,"a_s": 3.10, "T_d": 9.60}
+fg_params = {"a_tSZ": 3.30, "a_kSZ": 1.60, "a_p": 6.90, "beta_p": 2.08, "a_c": 4.90, "beta_c": 2.20, "a_s": 3.10, "a_gtt": 2.79, "a_gte": 0.36, "a_gee": 0.13, "a_psee": 0.05, "a_pste": 0, "xi": 0.1, "T_d": 9.60}
 
 #sim
 iStart = 0

--- a/project/data_analysis/python/get_best_fit_mflike.py
+++ b/project/data_analysis/python/get_best_fit_mflike.py
@@ -54,14 +54,18 @@ np.savetxt("%s/lcdm.dat" % bestfit_dir, np.transpose([ell, clth["TT"], clth["EE"
     
 # we will now use mflike (and in particular the fg module) to get the best fit foreground model
 # we will only include foreground in tt, note that for now only extragalactic foreground are present
-import mflike as mfl
+from mflike import theoryforge_MFLike as th_mflike
+ThFo = th_mflike.TheoryForge_MFLike()
 
 fg_norm = d["fg_norm"]
 fg_components =  d["fg_components"]
 components = {"tt": fg_components, "ee": [], "te": []}
 fg_model =  {"normalisation":  fg_norm, "components": components}
 fg_params = d["fg_params"]
-fg_dict = mfl.get_foreground_model(fg_params, fg_model, freq_list, ell)
+
+ThFo.foregrounds = fg_model
+ThFo._init_foreground_model()
+fg_dict = ThFo._get_foreground_model(ell=ell, freqs_order=freq_list,  **fg_params)
 
 spectra = ["TT", "TE", "TB", "ET", "BT", "EE", "EB", "BE", "BB"]
 


### PR DESCRIPTION
This repairs the `get_best_fit_mflike.py` script, which currently calls `mflike.get_foreground_model()`. This function doesn't exist as far as I can find. I've also added additional foreground parameters from `project/maps2params` to get the foreground model working.
