### PR TITLE
upgrade slurm submission script to give noise sim type

### DIFF
--- a/project/data_analysis/python/montecarlo/advanced_noise_sims.rst
+++ b/project/data_analysis/python/montecarlo/advanced_noise_sims.rst
@@ -85,7 +85,9 @@ We also provide an example slurm script, ``submit_noise_sim.slurm``, which you c
 
 .. code:: shell
 
-    sbatch submit_noise_sim.slurm
+    sbatch submit_noise_sim.slurm gaussian
+    sbatch submit_noise_sim.slurm tiled
+    sbatch submit_noise_sim.slurm wavelet
 
 This particular script runs 128 realizations of the chosen sim provided in the SLURM script, by 
 performing 8 sims at a time. 

--- a/project/data_analysis/python/montecarlo/submit_noise_sim.slurm
+++ b/project/data_analysis/python/montecarlo/submit_noise_sim.slurm
@@ -1,12 +1,12 @@
 #!/bin/bash
 #SBATCH --qos=regular
 #SBATCH --account=mp107
-#SBATCH --time=6:00:00
+#SBATCH --time=1:00:00
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
-#SBATCH --cpus-per-task=32
+#SBATCH --cpus-per-task=64
 #SBATCH --constraint=haswell
-#SBATCH --array=0-15
+#SBATCH --array=128-255
 
 cd /global/cscratch1/sd/xzackli/PSpipe/project/data_analysis/
 
@@ -14,6 +14,8 @@ module load python intel
 source activate ps38
 export PYTHONPATH=/global/cscratch1/sd/xzackli/PSpipe/project/data_analysis/python/:/global/homes/x/xzackli/src/enlib:$PYTHONPATH
 export HDF5_USE_FILE_LOCKING=FALSE
-export OMP_NUM_THREADS=16
+export OMP_NUM_THREADS=32
 
-srun python -u python/montecarlo/mc_mnms_get_spectra.py paramfiles/global_dr6_v3_4pass_pa6_tiled.dict $SLURM_ARRAY_TASK_ID
+echo "noisetype: $1"
+
+srun python -u python/montecarlo/mc_mnms_get_spectra.py paramfiles/global_dr6_v3_4pass_pa6_gaussian.dict $SLURM_ARRAY_TASK_ID $SLURM_ARRAY_TASK_ID --noisetype $1


### PR DESCRIPTION
Just a quick change, this makes it easy to run different noise sim types by giving a command-line argument to sbatch in the example slurm script.

i.e.
```bash
sbatch submit_noise_sim.slurm gaussian
sbatch submit_noise_sim.slurm tiled
sbatch submit_noise_sim.slurm wavelet
```