### PR TITLE
fix #102 by providing iii as the seed for alms and fglms

### DIFF
--- a/project/data_analysis/python/montecarlo/mc_get_spectra.py
+++ b/project/data_analysis/python/montecarlo/mc_get_spectra.py
@@ -107,8 +107,8 @@ for iii in subtasks:
     # cmb alms will be of shape (3, lm) 3 standing for T,E,B
     # fglms will be of shape (nfreq, lm) and is T only
     
-    alms = curvedsky.rand_alm(ps_cmb, lmax=lmax, dtype=sim_alm_dtype)
-    fglms = curvedsky.rand_alm(ps_fg, lmax=lmax, dtype=sim_alm_dtype)
+    alms = curvedsky.rand_alm(ps_cmb, lmax=lmax, seed=(iii, 101), dtype=sim_alm_dtype)
+    fglms = curvedsky.rand_alm(ps_fg, lmax=lmax, seed=(iii, 102), dtype=sim_alm_dtype)
     
     master_alms = {}
     nsplits = {}

--- a/project/data_analysis/python/montecarlo/mc_mnms_get_spectra.py
+++ b/project/data_analysis/python/montecarlo/mc_mnms_get_spectra.py
@@ -236,8 +236,8 @@ for iii in subtasks:
     # cmb alms will be of shape (3, lm) 3 standing for T,E,B
     # fglms will be of shape (nfreq, lm) and is T only
     
-    alms = curvedsky.rand_alm(ps_cmb, lmax=lmax, dtype=sim_alm_dtype)
-    fglms = curvedsky.rand_alm(ps_fg, lmax=lmax, dtype=sim_alm_dtype)
+    alms = curvedsky.rand_alm(ps_cmb, lmax=lmax, seed=(iii, 101), dtype=sim_alm_dtype)
+    fglms = curvedsky.rand_alm(ps_fg, lmax=lmax, seed=(iii, 102), dtype=sim_alm_dtype)
     
     master_alms = {}
     nsplits = {}


### PR DESCRIPTION
This passes the task ID as a seed for the RNG when creating signal and foreground sims. I also pass an additional integer so that the signal and foregrounds are not correlated by the RNG accidentally.