### PR TITLE
Remove obsolete part of README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,16 +60,6 @@ Then you can install the ``PSpipe`` library and its dependencies *via*
     $ pip install --user /where/to/clone
 
 
-At ``NERSC``
-------------------
-
-
-Instructions for installing ``pspy`` at ``NERSC`` are available at  `INSTALL_PSPY_NERSC <https://github.com/simonsobs/pspy/blob/master/INSTALL_NERSC.rst>`_.
-
-Instructions for installing ``NaMaster`` at ``NERSC`` are available at  `INSTALL_NAMASTER_NERSC <https://github.com/LSSTDESC/NaMaster/blob/master/NERSC_installation.md>`_.
-
-
-
 Using ``docker``
 ----------------
 


### PR DESCRIPTION
The NERSC instructions are a bit obsolete : first the pspy installation instructions do not exist anymore and installing NaMaster is none of our business