### PR TITLE
Add convention file for setting pspipe global variables

### DIFF
--- a/pspipe/conventions.py
+++ b/pspipe/conventions.py
@@ -1,0 +1,32 @@
+import os
+import sys
+
+# Setting directory name conventions
+directories = (
+    "windows",
+    "mcms",
+    "alms",
+    "spectra",
+    "best_fits",
+    "noise_model",
+    "sq_win_alms",
+    "covariances",
+)
+
+
+_product_dir = "."
+
+
+def _get_directory(name):
+    full_path = os.path.join(_product_dir, name)
+    os.makedirs(full_path, exist_ok=True)
+    return full_path
+
+
+module = sys.modules[__name__]
+
+for d in directories:
+    setattr(module, f"get_{d}_dir", lambda d=d: _get_directory(d))
+
+# pspy spectra order
+spectra = ["TT", "TE", "TB", "ET", "BT", "EE", "EB", "BE", "BB"]


### PR DESCRIPTION
This PR sets some static strings for defining directory paths to be used in `pspipe` pipeline scripts. Importing and using can be done as simply as
```python
from pspipe.conventions import get_windows_dir
windows_dir = get_windows_dir()
```
or
```python
from pspipe import conventions as cvt
winows_dir = cvt.get_windows_dir()
```

When getting directory, the directory path is automatically created.

Directory paths are dynamically added and so adding new path must be (and only) done with the `directories` tuple. 