### PR TITLE
Ensure axes are always 2D array

### DIFF
--- a/project/data_analysis/python/get_best_fit_mflike.py
+++ b/project/data_analysis/python/get_best_fit_mflike.py
@@ -104,6 +104,7 @@ for comp in ["tSZ", "cibc", "tSZxCIB"]:
 
 for mode in ["tt", "te", "tb", "ee", "eb", "bb"]:
     fig, axes = plt.subplots(narrays, narrays, sharex=True, sharey=True, figsize=(16, 16))
+    axes = np.atleast_2d(axes)
     indices = np.triu_indices(narrays)[::-1]
     for i, cross in enumerate(spectra_list):
         name1, name2 = cross.split("x")


### PR DESCRIPTION
In case, only one array is required `plt.subplots(1, 1)` return only one axes avoiding using indices selection. `np.atleast_2d` ensures the object is always a 2D array