### PR TITLE
change to published noise config (correct calibrations)

### DIFF
--- a/project/ACT_DR6/python/montecarlo/mc_mnms_get_nlms.py
+++ b/project/ACT_DR6/python/montecarlo/mc_mnms_get_nlms.py
@@ -39,7 +39,7 @@ arrays_alias = {
 
 # Load the noise models
 noise_models = {
-    wafer_name: nm.BaseNoiseModel.from_config("act_dr6v4", d[f"noise_sim_type_{wafer_name}"], *arrays_alias[wafer_name].keys())
+    wafer_name: nm.BaseNoiseModel.from_config("act_dr6.02_noise", d[f"noise_sim_type_{wafer_name}"], *arrays_alias[wafer_name].keys())
     for sv in surveys for wafer_name in sorted({ar.split("_")[0] for ar in d[f"arrays_{sv}"]})
 }
 


### PR DESCRIPTION
This changes the name of the configuration in the noise simulation script from `act_dr6v4` to `act_dr6.02_noise`. The latter will apply the calibration factors of the published maps to the simulations under the hood, so they are consistent with the published maps.

Note 1: prior to this change, non-ACT users would have gotten an error since the products corresponding to the `act_dr6v4` config are blocked by group permissions.

~Note 2: as of right now (2025/04/18, 3PM EDT), all users will get an error because the calibration factor files are not yet moved to the public NERSC location (Ted is working on this).~

Note 3: this change only applies to the standard maps. The custom null maps have an analogous simple change that can be made, but from my reading of the code the paramfiles for the custom null tests still point to "dr6v4" maps, with "dr6v4" calibrations (i.e., the calibrations are not "1" as in the "dr6.02" paramfiles), so I haven't made the change to the custom null noise model scripts.